### PR TITLE
Redesign room lobby with two-column layout

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -1,17 +1,17 @@
 import { motion } from 'motion/react'
-import { Users } from 'lucide-react'
+import { Users, Check } from 'lucide-react'
 import type { GameDefinition } from '@/types/game'
 
-const colorMap: Record<string, { bg: string; text: string; border: string; hoverBorder: string }> = {
-  'neon-green': { bg: 'bg-neon-green/10', text: 'text-neon-green', border: 'border-neon-green/20', hoverBorder: 'group-hover:border-neon-green/40' },
-  'neon-pink': { bg: 'bg-neon-pink/10', text: 'text-neon-pink', border: 'border-neon-pink/20', hoverBorder: 'group-hover:border-neon-pink/40' },
-  'neon-blue': { bg: 'bg-neon-blue/10', text: 'text-neon-blue', border: 'border-neon-blue/20', hoverBorder: 'group-hover:border-neon-blue/40' },
-  'neon-yellow': { bg: 'bg-neon-yellow/10', text: 'text-neon-yellow', border: 'border-neon-yellow/20', hoverBorder: 'group-hover:border-neon-yellow/40' },
-  'neon-purple': { bg: 'bg-neon-purple/10', text: 'text-neon-purple', border: 'border-neon-purple/20', hoverBorder: 'group-hover:border-neon-purple/40' },
-  'neon-orange': { bg: 'bg-neon-orange/10', text: 'text-neon-orange', border: 'border-neon-orange/20', hoverBorder: 'group-hover:border-neon-orange/40' },
+const colorMap: Record<string, { bg: string; text: string; border: string }> = {
+  'neon-green': { bg: 'bg-neon-green/10', text: 'text-neon-green', border: 'border-neon-green/30' },
+  'neon-pink': { bg: 'bg-neon-pink/10', text: 'text-neon-pink', border: 'border-neon-pink/30' },
+  'neon-blue': { bg: 'bg-neon-blue/10', text: 'text-neon-blue', border: 'border-neon-blue/30' },
+  'neon-yellow': { bg: 'bg-neon-yellow/10', text: 'text-neon-yellow', border: 'border-neon-yellow/30' },
+  'neon-purple': { bg: 'bg-neon-purple/10', text: 'text-neon-purple', border: 'border-neon-purple/30' },
+  'neon-orange': { bg: 'bg-neon-orange/10', text: 'text-neon-orange', border: 'border-neon-orange/30' },
 }
 
-export default function GameCard({ game, index }: { game: GameDefinition; index: number }) {
+export default function GameCard({ game, index, selected }: { game: GameDefinition; index: number; selected?: boolean }) {
   const colors = colorMap[game.color] ?? colorMap['neon-green']
 
   return (
@@ -20,36 +20,50 @@ export default function GameCard({ game, index }: { game: GameDefinition; index:
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.08, duration: 0.4, ease: 'easeOut' }}
     >
-      <div className="gradient-border group transition-colors duration-200 hover:border-border-light">
-        <div className="p-6">
-          <div className={`w-14 h-14 rounded-2xl ${colors.bg} border ${colors.border} ${colors.hoverBorder} flex items-center justify-center text-2xl mb-4 transition-colors`}>
-            {game.emoji}
+      <div className={`gradient-border group transition-colors duration-200 ${
+        selected
+          ? `!border-2 ${colors.border}`
+          : 'hover:border-border-light'
+      }`}>
+        <div className="p-5">
+          <div className="flex items-start gap-3.5">
+            <div className={`w-11 h-11 rounded-xl ${colors.bg} border ${colors.border} flex items-center justify-center text-xl shrink-0`}>
+              {game.emoji}
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <h3 className="font-display text-sm text-text-primary tracking-wide truncate">
+                  {game.name}
+                </h3>
+                {selected && (
+                  <div className={`w-5 h-5 rounded-full ${colors.bg} border ${colors.border} flex items-center justify-center shrink-0`}>
+                    <Check className={`w-3 h-3 ${colors.text}`} />
+                  </div>
+                )}
+              </div>
+              <p className="text-text-secondary text-xs leading-relaxed mt-0.5 line-clamp-2">
+                {game.description}
+              </p>
+            </div>
           </div>
 
-          <h3 className="font-display text-lg text-text-primary mb-1 tracking-wide">
-            {game.name}
-          </h3>
-
-          <p className="text-text-secondary text-sm leading-relaxed mb-4">
-            {game.description}
-          </p>
-
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-1.5 text-text-muted text-xs">
-              <Users className="w-3.5 h-3.5" />
+          <div className="flex items-center justify-between mt-3.5 pt-3 border-t border-border/30">
+            <div className="flex items-center gap-1.5 text-text-muted text-[11px]">
+              <Users className="w-3 h-3" />
               <span>{game.config.minPlayers}-{game.config.maxPlayers} joueurs</span>
             </div>
-          </div>
 
-          {game.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-4 pt-4 border-t border-border/30">
-              {game.tags.map(tag => (
-                <span key={tag} className="text-[10px] uppercase tracking-wider text-text-muted bg-surface-light px-2 py-0.5 rounded-md">
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
+            {game.tags.length > 0 && (
+              <div className="flex gap-1.5">
+                {game.tags.map(tag => (
+                  <span key={tag} className="text-[10px] uppercase tracking-wider text-text-muted bg-surface-light px-2 py-0.5 rounded-md">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </motion.div>

--- a/src/components/RoomLobby.tsx
+++ b/src/components/RoomLobby.tsx
@@ -1,29 +1,29 @@
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'motion/react'
-import { Crown, X } from 'lucide-react'
+import { Crown, X, Copy, Check, Users, LogOut } from 'lucide-react'
+import { useState } from 'react'
 import { useRoomStore } from '@/stores/roomStore'
 import { useRoom } from '@/hooks/useRoom'
 import { registry } from '@/lib/registry'
 import type { GameSetting } from '@/types/game'
-import RoomCodeDisplay from './RoomCodeDisplay'
 import GameCard from './GameCard'
 
-const colorBgMap: Record<string, string> = {
-  'neon-green': 'bg-neon-green/10',
-  'neon-pink': 'bg-neon-pink/10',
-  'neon-blue': 'bg-neon-blue/10',
-  'neon-yellow': 'bg-neon-yellow/10',
-  'neon-purple': 'bg-neon-purple/10',
-  'neon-orange': 'bg-neon-orange/10',
+const colorRingMap: Record<string, string> = {
+  'neon-green': 'ring-neon-green/60',
+  'neon-pink': 'ring-neon-pink/60',
+  'neon-blue': 'ring-neon-blue/60',
+  'neon-yellow': 'ring-neon-yellow/60',
+  'neon-purple': 'ring-neon-purple/60',
+  'neon-orange': 'ring-neon-orange/60',
 }
 
-const colorBorderMap: Record<string, string> = {
-  'neon-green': 'border-neon-green/30',
-  'neon-pink': 'border-neon-pink/30',
-  'neon-blue': 'border-neon-blue/30',
-  'neon-yellow': 'border-neon-yellow/30',
-  'neon-purple': 'border-neon-purple/30',
-  'neon-orange': 'border-neon-orange/30',
+const colorDotMap: Record<string, string> = {
+  'neon-green': 'bg-neon-green',
+  'neon-pink': 'bg-neon-pink',
+  'neon-blue': 'bg-neon-blue',
+  'neon-yellow': 'bg-neon-yellow',
+  'neon-purple': 'bg-neon-purple',
+  'neon-orange': 'bg-neon-orange',
 }
 
 export default function RoomLobby() {
@@ -31,77 +31,148 @@ export default function RoomLobby() {
   const room = useRoomStore(s => s.room)!
   const isHost = useRoomStore(s => s.isHost())
   const { selectGame, updateSettings, startGame, kickPlayer, leaveRoom } = useRoom()
+  const [copied, setCopied] = useState(false)
 
   const handleLeave = () => {
     navigate('/')
     leaveRoom()
   }
-  const games = registry.getAll()
 
+  const games = registry.getAll()
   const selectedGame = room.gameId ? registry.get(room.gameId) : null
   const connectedCount = room.players.filter(p => p.connected).length
   const canStart = selectedGame && connectedCount >= (selectedGame?.config.minPlayers ?? 2)
 
-  return (
-    <div className="space-y-8">
-      <RoomCodeDisplay code={room.code} />
+  const inviteLink = `${window.location.origin}/room/${room.code}`
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(inviteLink)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
-      {/* Players */}
-      <div>
-        <h2 className="font-display text-lg text-text-secondary mb-4 tracking-wide">
-          JOUEURS ({room.players.length})
-        </h2>
-        <div className="space-y-2">
-          {room.players.map((player, i) => (
-            <motion.div
-              key={player.id}
-              initial={{ opacity: 0, x: -12 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: i * 0.05 }}
-              className={`flex items-center gap-3 ${colorBgMap[player.color] ?? 'bg-surface'} border ${colorBorderMap[player.color] ?? 'border-border/50'} rounded-xl p-3 group`}
-            >
-              <img src={player.avatar} alt="" className="w-8 h-8 rounded-full" />
-              <span className={`font-medium flex-1 ${player.connected ? 'text-text-primary' : 'text-text-muted line-through'}`}>
-                {player.name}
-              </span>
-              {player.id === room.hostId && (
-                <span className="flex items-center gap-1 text-xs bg-neon-yellow/10 text-neon-yellow px-2 py-0.5 rounded-md">
-                  <Crown className="w-3 h-3" />
-                  Host
-                </span>
-              )}
-              {isHost && player.id !== room.hostId && (
-                <button
-                  onClick={() => kickPlayer(player.id)}
-                  className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-neon-pink transition-all"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              )}
-            </motion.div>
-          ))}
+  return (
+    <div className="flex flex-col lg:flex-row gap-6 lg:gap-8">
+
+      {/* ─── LEFT: Room info + Players ─── */}
+      <div className="lg:w-80 xl:w-96 shrink-0 flex flex-col gap-4">
+
+        {/* Room code */}
+        <div className="gradient-border">
+          <div className="p-5">
+            <p className="text-[11px] uppercase tracking-[0.2em] text-text-muted font-medium mb-3">
+              Code de la room
+            </p>
+            <div className="flex items-center gap-3">
+              <p className="font-display text-4xl tracking-[0.25em] text-neon-green text-glow-green">
+                {room.code}
+              </p>
+              <button
+                onClick={copyLink}
+                className="ml-auto p-2.5 rounded-lg bg-surface-light border border-border/50 text-text-muted hover:text-neon-green hover:border-neon-green/30 transition-colors"
+              >
+                {copied ? <Check className="w-4 h-4 text-neon-green" /> : <Copy className="w-4 h-4" />}
+              </button>
+            </div>
+            {copied && (
+              <p className="text-neon-green text-xs font-medium mt-2">Lien copie !</p>
+            )}
+          </div>
         </div>
+
+        {/* Players */}
+        <div className="gradient-border flex-1">
+          <div className="px-5 pt-5 pb-3 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Users className="w-4 h-4 text-text-muted" />
+              <h2 className="text-[11px] uppercase tracking-[0.2em] text-text-muted font-medium">
+                Joueurs
+              </h2>
+            </div>
+            <span className="text-xs tabular-nums font-medium text-text-secondary bg-surface-light px-2 py-0.5 rounded-md">
+              {connectedCount}/{room.players.length}
+            </span>
+          </div>
+
+          <div className="px-3 pb-3 space-y-1">
+            {room.players.map((player, i) => (
+              <motion.div
+                key={player.id}
+                initial={{ opacity: 0, x: -12 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: i * 0.05 }}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-xl group hover:bg-surface-light/60 transition-colors"
+              >
+                <div className="relative">
+                  <img
+                    src={player.avatar}
+                    alt=""
+                    className={`w-9 h-9 rounded-full ring-2 ${colorRingMap[player.color] ?? 'ring-border'} ${!player.connected ? 'opacity-40 grayscale' : ''}`}
+                  />
+                  {player.connected && (
+                    <span className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full ${colorDotMap[player.color] ?? 'bg-neon-green'} border-2 border-surface`} />
+                  )}
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <span className={`text-sm font-medium block truncate ${player.connected ? 'text-text-primary' : 'text-text-muted line-through'}`}>
+                    {player.name}
+                  </span>
+                  {player.id === room.hostId && (
+                    <span className="flex items-center gap-1 text-[10px] text-neon-yellow font-medium">
+                      <Crown className="w-2.5 h-2.5" />
+                      Host
+                    </span>
+                  )}
+                </div>
+
+                {isHost && player.id !== room.hostId && (
+                  <button
+                    onClick={() => kickPlayer(player.id)}
+                    className="opacity-0 group-hover:opacity-100 p-1 rounded-md text-text-muted hover:text-neon-pink hover:bg-neon-pink/10 transition-all"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        {/* Leave */}
+        <button
+          onClick={handleLeave}
+          className="flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-border bg-surface text-text-secondary text-sm hover:text-neon-pink hover:border-neon-pink/30 transition-colors"
+        >
+          <LogOut className="w-4 h-4" />
+          Quitter la room
+        </button>
       </div>
 
-      {/* Game selection */}
-      <div>
-        <h2 className="font-display text-lg text-text-secondary mb-4 tracking-wide">
-          {isHost ? 'CHOISIS UN JEU' : 'JEU SELECTIONNE'}
-        </h2>
+      {/* ─── RIGHT: Game selection + Settings + Launch ─── */}
+      <div className="flex-1 flex flex-col gap-5 min-w-0">
 
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-lg text-text-secondary tracking-wide">
+            {isHost ? 'CHOISIS UN JEU' : 'JEU SELECTIONNE'}
+          </h2>
+          {selectedGame && (
+            <span className="text-xs text-neon-green bg-neon-green/10 border border-neon-green/20 px-2.5 py-1 rounded-full font-medium">
+              {selectedGame.emoji} {selectedGame.name}
+            </span>
+          )}
+        </div>
+
+        {/* Games */}
         {isHost ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
             {games.map((game, i) => (
               <div
                 key={game.id}
                 onClick={() => selectGame(game.id)}
-                className={`cursor-pointer rounded-2xl transition-all ${
-                  room.gameId === game.id
-                    ? 'outline-2 outline-neon-green outline-offset-2'
-                    : ''
-                }`}
+                className="cursor-pointer"
               >
-                <GameCard game={game} index={i} />
+                <GameCard game={game} index={i} selected={room.gameId === game.id} />
               </div>
             ))}
           </div>
@@ -119,9 +190,9 @@ export default function RoomLobby() {
           </div>
         )}
 
-        {/* Game settings */}
+        {/* Settings */}
         {selectedGame?.settings && selectedGame.settings.length > 0 && (
-          <div className="mt-4 space-y-3">
+          <div className="space-y-2">
             {selectedGame.settings.filter((s) => {
               if (!s.visibleWhen) return true
               const depValue = room.settings[s.visibleWhen.settingId] ??
@@ -137,32 +208,26 @@ export default function RoomLobby() {
             ))}
           </div>
         )}
-      </div>
 
-      {/* Actions */}
-      <div className="flex gap-3 justify-center">
-        <button
-          onClick={handleLeave}
-          className="px-6 py-3 bg-surface border border-border rounded-xl text-text-secondary hover:text-text-primary hover:border-border-light transition-all"
-        >
-          Quitter
-        </button>
-        {isHost && (
-          <button
-            onClick={startGame}
-            disabled={!canStart}
-            className="px-8 py-3 bg-neon-green/10 border border-neon-green/20 text-neon-green rounded-xl font-display tracking-wide hover:bg-neon-green/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-          >
-            LANCER LA PARTIE
-          </button>
+        {/* Launch */}
+        <div className="flex gap-3 mt-auto pt-4">
+          {isHost && (
+            <button
+              onClick={startGame}
+              disabled={!canStart}
+              className="flex-1 py-3.5 rounded-xl font-display tracking-wide text-lg bg-neon-green/10 border border-neon-green/20 text-neon-green hover:bg-neon-green/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              LANCER LA PARTIE
+            </button>
+          )}
+        </div>
+
+        {isHost && selectedGame && !canStart && (
+          <p className="text-center text-text-muted text-xs">
+            Il faut au moins {selectedGame.config.minPlayers} joueurs connectes pour lancer
+          </p>
         )}
       </div>
-
-      {isHost && selectedGame && !canStart && (
-        <p className="text-center text-text-muted text-xs">
-          Il faut au moins {selectedGame.config.minPlayers} joueurs connectes pour lancer
-        </p>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Split lobby into two-column layout: left (room code + players + leave) / right (game selection + settings + launch)
- Compact horizontal game cards with inline selection check indicator
- Integrated room code display directly into lobby (removed RoomCodeDisplay dependency)
- Player avatars now use colored ring + connection dot instead of colored background rows

## Test plan
- [ ] Verify two-column layout on desktop (lg+) and single-column on mobile
- [ ] Test room code copy button and feedback message
- [ ] Verify game selection highlight and check icon on selected card
- [ ] Test host vs non-host views (game selection vs waiting state)
- [ ] Verify game settings and launch button behavior
- [ ] Test player kick functionality on hover